### PR TITLE
code font size rem->em

### DIFF
--- a/static/css/main-site.css
+++ b/static/css/main-site.css
@@ -1069,7 +1069,7 @@ pre code {
 
 /* this styles the inline code */
 code {
-  font-size: 1rem;
+  font-size: 1em;
   color: #606060;
   display: inline-block;
   margin: 1px 5px;
@@ -2139,3 +2139,5 @@ a > svg.anchor-symbol:hover {
 .listItem .itemImage {
     overflow: hidden;
  }
+ 
+


### PR DESCRIPTION
This fixes code font sizing when used in headers and within the TOC